### PR TITLE
Fixed "Old Name" Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,22 +6,22 @@ body:
   attributes:
     value: |
       **Please read before creating a new bug report:**
-      1. Make sure there is not already an issue for this bug by [searching in **both** open and closed issues](https://github.com/stenzek/duckstation/issues?q=is%3Aissue+sort%3Aupdated-desc+).
+      1. Make sure there is not already an issue for this bug by [searching in **both** open and closed issues](https://github.com/cameronbosch/quackstation/issues?q=is%3Aissue+sort%3Aupdated-desc+).
       2. All enhancements **must** be off. To quickly disable all enhancements with affecting your normal configuration, you can check **Disable All Enhancements** in Advanced Options.
       3. All advanced options **must** be at their default values.
       4. No cheats may be active. If you were using cheats, they should be disabled, and the game must be rebooted before reporting the bug.
       5. Do not share save state files. (Sharing memory card files is OK.)
       6. Verify your BIOS and game dumps, as we can not assist with issues resulting from bad dumps.
-      7. If playing PAL region software, please check whether or not the game has LibCrypt protection. If it does, make sure you have a [correct SBI file](https://github.com/stenzek/duckstation#libcrypt-protection-and-sbi-files).
-      8. Please post your bug report in English, as this is the only language spoken by the developers. The [Discord server](https://discord.gg/Buktv3t) has many helpful people if you need help translating.
-      9. Issues about the libretro core will be deleted (you will be blocked from the repository if you create such an issue). That core is not DuckStation, it is a broken fork, and has nothing to do with us.
+      7. If playing PAL region software, please check whether or not the game has LibCrypt protection. If it does, make sure you have a [correct SBI file](https://github.com/cameronbosch/quackstation#libcrypt-protection-and-sbi-files).
+      8. Please post your bug report in English, as this is the only language spoken by the developers. The Matrix room has many helpful people if you need help translating.
+      9. Issues about the libretro core will be marked as "completed" and "won't fix". We do not control that fork and it has nothing to do with us.
 
 - type: input
   attributes:
     label: Game details
     description: |
       Specify the game's serial code, full name and region (USA, Europe, Japan).
-    placeholder: SLUS-00404 Ace Combat 2 (USA)
+    placeholder: SLUS-00067 Castlevania: Symphony of the Night (USA)
   validations:
     required: true
 
@@ -47,25 +47,25 @@ body:
   attributes:
     label: Software and hardware information
     description: |
-      For desktops and laptops, specify your OS version, CPU and graphics card information (model and driver version).
+      For desktops and laptops, specify your OS version (and if on Linux, the distro), CPU and graphics card information (model and driver version of both the iGPU and dGPU if there are multiple available on your system).
       For mobile devices, specify your OS version and device model name.
-    placeholder: Windows 10, Intel Core i7-7500U, Intel HD Graphics 620 (27.20.100.9616)
+    placeholder: Arch Linux, AMD Ryzen 9 9800X3D, AMD Radeon RX 9070 XT
   validations:
     required: true
 
 - type: input
   attributes:
-    label: DuckStation version
+    label: QuackStation version
     description: |
-      Specify your DuckStation version and how you installed it (GitHub Releases, GitHub Actions, compiled from source, …).
+      Specify your QuackStation version and how you installed it (GitHub Releases, GitHub Actions, compiled from source, installed from Flatpak, …).
   validations:
     required: true
 
 - type: dropdown
   attributes:
-    label: DuckStation rendering backend
+    label: QuackStation rendering backend
     description: |
-      Specify the DuckStation rendering backend you were using when reporting this issue.
+      Specify the QuackStation rendering backend you were using when reporting this issue.
       If you can reproduce this issue using more than one rendering backend, mention it in the **Description of the issue/bug** section above.
       When reporting a graphics-related issue, please test all the rendering backends you can before submitting the issue.
     options:
@@ -79,9 +79,9 @@ body:
 
 - type: input
   attributes:
-    label: DuckStation controller backend, drivers and wrappers
+    label: QuackStation controller backend, drivers and wrappers
     description: |
-      Which controller backend are you using in DuckStation's General Settings?
+      Which controller backend are you using in QuackStation's General Settings?
       Have you installed any drivers or wrappers on your system, or do you have any programs like Steam open?
       If so, specify which drivers/wrappers you are using.
   validations:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Game compatibility list
-    url: https://docs.google.com/spreadsheets/d/1H66MxViRjjE5f8hOl5RQmF5woS1murio2dsLn14kEqo/edit
+    url: To be remade
     about: Please refer to the game compatibility list before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,15 +1,15 @@
 name: Feature request
-description: Request a feature to be added or improved in DuckStation
+description: Request a feature to be added or improved in QuackStation
 body:
 
 - type: markdown
   attributes:
     value: |
       **Please read before creating a new feature request:**
-      1. Make sure there is not already an issue for this feature request by [searching in **both** open and closed issues](https://github.com/stenzek/duckstation/issues?q=is%3Aissue+sort%3Aupdated-desc+).
+      1. Make sure there is not already an issue for this feature request by [searching in **both** open and closed issues](https://github.com/cameronbosch/quackstation/issues?q=is%3Aissue+sort%3Aupdated-desc+).
       2. Please open **one issue per requested feature**. Do not cram several unrelated feature requests in a single issue, as this makes it harder for contributors to track what's being worked on.
-      3. Please post your feature request in English, as this is the only language spoken by the developers. The [Discord server](https://discord.gg/Buktv3t) has many helpful people if you need help translating.
-      4. Issues about the libretro core will be deleted (you will be blocked from the repository if you create such an issue). That core is not DuckStation, it is a broken fork, and has nothing to do with us.
+      3. Please post your bug report in English, as this is the only language spoken by the developers. The Matrix room has many helpful people if you need help translating.
+      4. Issues about the libretro core will be marked as "completed" and "won't fix". We do not control that fork and it has nothing to do with us.
 
 - type: textarea
   attributes:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 This project started as an archived copy of DuckStation, a PSX emulator with a Qt front-end. It is now a separate project, aka, a hard fork of DuckStation.
 
 ## Why fork Duck Station?
-Prior to a license change that moved it from being a free and open source PSX emulator, DuckStation wss basically the only modern PSX emulator available for Linux and on Flathub. However, as of commit `25bc8a64803df7e702db66e0f11d7b7d0fdc99f2` on 1 September 2024, the main developer of DuckStation, stenzek, updated their license, changing it from the GPLv3 license to the PolyForm Strict License 1.0.0, which is a source available but proprietary (non-free) software license. It was later switched to the CC-BY-NC-ND license, which is also not a free and open source license, and is also not meant for licensing software under. This, plus stenzek making other erratic moves such as threatening to break Arch Linux users from maintaining an AUR package, made me worry about the future of PSX emulation on Linux. The final nail in the coffin was that in late October 2025, the FlatHub package was marked as deprecated and is no longer being updated. As it is not under a FOSS license anymore and stenzek has been behaving rather rudely and erractically to the FOSS and especially the Linux community, I thought somebody would step up to fork the final FOSS version of DuckStation. Unfortunately, until 30 October 2025, nobody stepped up to properly fork the final GPLv3 version of DuckStation, leaving FlatHub without _any_ PSX emulator at all.
+Prior to a license change that moved it from being a free and open source PSX emulator, DuckStation wss basically the only modern PSX emulator available for Linux and on Flathub. However, as of commit `25bc8a64803df7e702db66e0f11d7b7d0fdc99f2` on 1 September 2024, the main developer of DuckStation, stenzek, updated their license, changing it from the GPLv3 license to the PolyForm Strict License 1.0.0, which is a source available but proprietary (non-free) software license. It was later switched to the CC-BY-NC-ND license, which is also not a free and open source license, and is also not meant for licensing software under. This, plus stenzek making other erratic moves such as threatening to break Arch Linux users from maintaining an AUR package, made me worry about the future of PSX emulation on Linux. The final nail in the coffin was that in late October 2025, the FlatHub package was marked as deprecated and is no longer being updated. As it is not under a FOSS license anymore and stenzek has been behaving rather rudely and erractically to the FOSS and especially the Linux community, I thought somebody would step up to fork the final FOSS version of DuckStation. Unfortunately, until 30 October 2025, nobody stepped up to properly fork the final GPLv3 version of DuckStation, leaving Flathub without _any_ PSX emulator at all.
 
 For those who were wondering, the change that officially moved DuckStation from the GPLv3 to the first non FOSS license was shown here: <https://github.com/stenzek/duckstation/commit/9ca6b5430fb358b39f21ce0b2fc0268de954dd23>
+
+As of 29 July 2025, stenzek has continued to make erratic changes. For example: <https://youtu.be/2OMxCC6BFxE>
 
 The final GPLv3 version of DuckStation had been archived at https://codeberg.org/vimuser/duckstation by Leah Rowe. A massive thank you to her for doing this so I don't have to worry about "GPL violations" for accidently looking at post FOSS DuckStation.
 
@@ -20,13 +22,17 @@ In addition, because the logo for DuckStation is also likely a trademark held by
 ## So... Why the current name "QuackStation"?
 Well, "quack" is the sound ducks make, and a "quack" is also used to denorte a person who pretends in some way to have skills, knowledge, or other qualifications they do not possess. That's why the name was chosen.
 
+I know it sounds like a "typical protest fork name", but it is what it is.
+
 [Features](#features) | [Downloading and Running](#downloading-and-running) | [Building](#building) | [Disclaimers](#disclaimers)
 
 **Latest Builds for Windows 10/11 (x64/ARM64), Linux (AppImage/Flatpak), and macOS (11.0+ Universal):** https://github.com/cameronbosch/quackstation/releases/tag/latest
 
 **Game Compatibility List:** _This needs to be redone._
 
-**Discord Server:** Currently does not exist.
+**Matrix Room:** _Currently in the progress of being made._
+
+**We currently do not have a Discord server and likely never will because of [Discord becoming a privacy and security risk starting in March 2026](https://www.gamingonlinux.com/2026/02/discord-is-about-to-require-age-verification-for-everyone/) (this change was announced by them on 9 February 2026).**
 
 QuackStation is an simulator/emulator of the Sony PlayStation(TM) console, focusing on playability, speed, and long-term maintainability. The goal is to be as accurate as possible while maintaining performance suitable for low-end devices. "Hack" options are discouraged, the default configuration should support all playable games with only some of the enhancements having compatibility issues.
 
@@ -107,7 +113,7 @@ The only supported versions of DuckStation for Linux are the AppImage and Flatpa
 
 We plan to offer an official release on [Flathub](https://flathub.org/) again once the project gets back on track. This release will synchronized with the latest rolling/stable release on GitHub. This will become the primary and recommended way to use QuackStation once we get back on track.
 
-You **should not** install DuckStation from unofficial repositories such as the AUR, they are **known to be broken**.
+You **should not** install QuackStation from unofficial repositories such as the AUR, they are **known to be broken**.
 
 #### AppImage
 
@@ -122,8 +128,8 @@ The AppImages require a distribution equivalent to Ubuntu 22.04 or newer to run.
  - Go to https://github.com/cameronbosch/quackstation/releases/tag/latest, and download `quackstation-x64.flatpak`.
  - Run `flatpak install ./quackstation-x64.flatpak`.
 
-or, if you have FlatHub set up:
- - Run `flatpak install org.quackstation.QuackStation`. Please note that as of 30 October 2025, this will not work for now.
+or, if you have Flathub set up:
+ - Run `flatpak install flathub org.quackstation.QuackStation`. Please note that as of 30 October 2025, this will not work for now.
 
 Use `flatpak run org.quackstation.QuackStation` to start, or select `QuackStation` in the launcher of your desktop environment. Follow the Setup Wizard to get started.
  
@@ -155,7 +161,7 @@ If you have an external controller, you will need to map the buttons and sticks 
 
 A number of PAL region games use LibCrypt protection, requiring additional CD subchannel information to run properly. libcrypt not functioning usually manifests as hanging or crashing, but can sometimes affect gameplay too, depending on how the game implemented it.
 
-For these games, make sure that the CD image and its corresponding SBI (.sbi) file have the same name and are placed in the same directory. DuckStation will automatically load the SBI file when it is found next to the CD image.
+For these games, make sure that the CD image and its corresponding SBI (.sbi) file have the same name and are placed in the same directory. QuackStation will automatically load the SBI file when it is found next to the CD image.
 
 For example, if your disc image was named `Spyro3.cue`, you would place the SBI file in the same directory, and name it `Spyro3.sbi`.
 
@@ -170,7 +176,7 @@ Requirements:
 
 1. Clone the respository: `git clone https://github.com/cameronbosch/quackstation.git`.
 2. Download the dependencies pack from https://github.com/cameronbosch/quackstation-ext-qt-minimal/releases/download/latest/deps-x64.7z, and extract it to `dep\msvc`.
-3. Open the Visual Studio solution `duckstation.sln` in the root, or "Open Folder" for cmake build.
+3. Open the Visual Studio solution `quackstation.sln` in the root, or "Open Folder" for cmake build.
 4. Build solution.
 5. Binaries are located in `bin/x64`.
 6. Run `quackstation-qt-x64-Release.exe` or whichever config you used.
@@ -214,13 +220,22 @@ Requirements:
 The "User Directory" is where you should place your BIOS images, where settings are saved to, and memory cards/save states are saved by default.
 An optional [SDL game controller database file](#sdl-game-controller-database) can be also placed here.
 
-This is located in the following places depending on the platform you're using:
+For now, this is located in the following places depending on the platform you're using:
 
 - Windows: My Documents\DuckStation
 - Linux: `$XDG_DATA_HOME/duckstation`, or `~/.local/share/duckstation`.
 - macOS: `~/Library/Application Support/DuckStation`.
 
 So, if you were using Linux, you would place your BIOS images in `~/.local/share/duckstation/bios`. This directory will be created upon running QuackStation
+for the first time.
+
+We do plan to eventually transition to the following format:
+
+- Windows: My Documents\QuackStation
+- Linux: `$XDG_DATA_HOME/quackstation`, or `~/.local/share/quackstation`.
+- macOS: `~/Library/Application Support/QuackStation`.
+
+So, if you were using Linux, you would place your BIOS images in `~/.local/share/quackstation/bios`. This directory will be created upon running QuackStation
 for the first time.
 
 If you wish to use a "portable" build, where the user directory is the same as where the executable is located, create an empty file named `portable.txt`


### PR DESCRIPTION
Fixed two of the issue templates saying "DuckStation" instead of "QuackStation". Solves #1.